### PR TITLE
Refactor of Simple Alsa

### DIFF
--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/metronome.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/metronome.c
@@ -50,11 +50,13 @@ void beat(int delay)
 	struct timeval tv;
 	int dir;
 	int64_t d, corr, slp, cur, next;
+	unsigned int samplerate;
 	tv = start;
 	d = corr = 0;
 	dir = 0;
 	next = tv_to_u(start) + delay;
-	pcm_handle=init_pcm(infilename,&buf);
+	samplerate = init_sndfile(infilename,&buf);
+	pcm_handle=init_pcm(samplerate);
 	while (1) {
 		gettimeofday(&tv, 0);
 		slp = next - tv_to_u(tv) - corr;

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/metronome.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/metronome.c
@@ -46,7 +46,6 @@ void beat(int delay)
 {
 	snd_pcm_t *pcm_handle;
 	char *infilename = "/srv/trebletrouble/metro_1.wav" ;
-	short *buf = NULL ;
 	struct timeval tv;
 	int dir;
 	int64_t d, corr, slp, cur, next;
@@ -55,14 +54,14 @@ void beat(int delay)
 	d = corr = 0;
 	dir = 0;
 	next = tv_to_u(start) + delay;
-	samplerate = init_sndfile(infilename,&buf);
+	samplerate = init_sndfile(infilename);
 	pcm_handle=init_pcm(samplerate);
 	while (1) {
 		gettimeofday(&tv, 0);
 		slp = next - tv_to_u(tv) - corr;
 		usleep(slp);
 		gettimeofday(&tv, 0);
- 		sound(pcm_handle,buf);
+		play_sndfile(pcm_handle);
 		fflush(stdout);
  		dir = !dir;
  		cur = tv_to_u(tv);
@@ -70,7 +69,7 @@ void beat(int delay)
 		corr = (corr + d) / 2;
 		next += delay;
  	}
-	cleanup_pcm(&pcm_handle,&buf);
+	cleanup_pcm(&pcm_handle);
 }
  
 void metronome(int bpm)

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
@@ -1,4 +1,5 @@
-void cleanup_pcm(snd_pcm_t **pcm_handle,short **buf);
-unsigned int init_sndfile(char *infilename, short **buf);
+void cleanup_pcm(snd_pcm_t **pcm_handle);
+unsigned int init_sndfile(char *infilename);
 snd_pcm_t * init_pcm(unsigned int samplerate);
-void sound(snd_pcm_t *pcm_handle,short *buf);
+void play_sndfile(snd_pcm_t *pcm_handle);
+void sound(snd_pcm_t *pcm_handle, short *buf, int readcount);

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
@@ -1,3 +1,4 @@
-void sound(snd_pcm_t *pcm_handle,short *buf);
-snd_pcm_t* init_pcm(char *infilename,short **buf);
 void cleanup_pcm(snd_pcm_t **pcm_handle,short **buf);
+unsigned int init_sndfile(char *infilename, short **buf);
+snd_pcm_t * init_pcm(unsigned int samplerate);
+void sound(snd_pcm_t *pcm_handle,short *buf);


### PR DESCRIPTION
Refactor out playing a sound from a buffer so that it is possible to play a Wave file.

`init_pcm` only depends on the sample rate which is based off of the sndfile or the wav.

The buffer needs the number of to be initialized by the pcm device. That now lives inside of the play_sndfile instead of the metronome. As a bonus, this keeps the lifetime of the buffer to a minimum.

`init_sndfile` performs file I/O related initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trebletrouble/trebletrouble/87)
<!-- Reviewable:end -->
