### PR TITLE
Fix Tejan Audio

### DIFF
--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/audio_recorder.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/audio_recorder.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "simpleAlsa.h"
 #include "audio_recorder.h"
 
 /* added to fix implicit delcaration warnings for alloca in target files */
@@ -76,7 +77,7 @@ int recordWAV(Wave* wave, uint32_t duration)
     goto END_BUF;
   }
 
-  for (i = ((duration * 1000) / (hdr->sampleRate/ frames)); i > 0; i--) {
+  for (i = ((duration * 1000 * frames) / hdr->sampleRate); i > 0; i--) {
     err = snd_pcm_readi(handle, buffer, frames);
     if (err >= 0) {
       err *= hdr -> numChannels * (hdr -> bitsPerSample / 8);

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/audio_recorder.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/audio_recorder.c
@@ -16,7 +16,6 @@ int recordWAV(Wave* wave, uint32_t duration)
   snd_pcm_t *handle;
   snd_pcm_hw_params_t *params;
   unsigned int sampleRate;
-  int dir;
   WaveHeader* hdr;
   snd_pcm_uframes_t frames;
   const char *device; /* Integrated system microphone */

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/audio_recorder.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/audio_recorder.c
@@ -39,40 +39,7 @@ int recordWAV(Wave* wave, uint32_t duration)
   snd_pcm_hw_params_any(handle, params);
 
   /* ### Set the desired hardware paramteteres. ### */
-
-  /* Interleaved mode */
-  err = snd_pcm_hw_params_set_access(handle, params, SND_PCM_ACCESS_RW_INTERLEAVED);
-  if (err) {
-    fprintf(stderr, "Error setting interleaved mode: %s\n", snd_strerror(err));
-    goto END_PCM;
-  }
-
-  /* Signed 16-bit litte-endian format */
-  if (hdr-> bitsPerSample == 16) {
-    err = snd_pcm_hw_params_set_format(handle, params, SND_PCM_FORMAT_S16_LE);
-  } else {
-    err = snd_pcm_hw_params_set_format(handle, params, SND_PCM_FORMAT_U8);
-  }
-
-  if (err) {
-    fprintf(stderr, "Error setting format: %s\n", snd_strerror(err)); 
-    goto END_PCM;
-  }
-
-  /* Two channels (stereo) */
-  err = snd_pcm_hw_params_set_channels(handle, params, hdr -> numChannels);
-  if (err) {
-    fprintf(stderr, "Error setting channels: %s\n", snd_strerror(err));
-    goto END_PCM;
-  }
-
-  /* 44100 bits/second sampling rate (CD quality) */
-  sampleRate = hdr->sampleRate;
-  err = snd_pcm_hw_params_set_rate_near(handle, params, &sampleRate, &dir);
-  if (err) {
-    fprintf(stderr, "Error setting sampling rate (%d): %s\n", sampleRate, snd_strerror(err));
-    goto END_PCM;
-  }
+  init_pcm_params(handle, params, hdr->sampleRate, &dir, hdr->numChannels);
 
   /* Set period size */
   err = snd_pcm_hw_params_set_period_size_near(handle, params, &frames, &dir);

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/menu.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/menu.c
@@ -77,7 +77,7 @@ void play_song_menu(char* fbp, ScreenInput *si) {
 		compare_notes(expected[i], find_freq(pitch), i, fbp);
 		waveDestroy(wave);
 	}
-	cleanup_pcm(&pcmh);
+	cleanup_pcm(pcmh);
 	/* get_lcd_input(si); */
 	/* Reset notes to black */
 	clear_notes(0, expected, actual, fbp);

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/metronome.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/metronome.c
@@ -70,7 +70,7 @@ void beat(int delay)
 		corr = (corr + d) / 2;
 		next += delay;
  	}
-	cleanup_pcm(&pcm_handle);
+	cleanup_pcm(pcm_handle);
 }
  
 void metronome(int bpm)

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.c
@@ -56,21 +56,9 @@ static SNDFILE *infile = NULL;
 #define alloca(x) __builtin_alloca(x)
 #endif
 
-snd_pcm_t * init_pcm(unsigned int samplerate)
+void init_pcm_params(snd_pcm_t *pcm_handle, snd_pcm_hw_params_t *params, unsigned int samplerate, int *dir)
 {
-	snd_pcm_hw_params_t *params;
-	snd_pcm_t *pcm_handle;
-	int dir;
-	unsigned int tmp,pcm;
-	dir = 0;
-        /* Open the PCM device in playback mode */
-	if ((pcm = snd_pcm_open(&pcm_handle, PCM_DEVICE,
-				SND_PCM_STREAM_PLAYBACK, 0)) < 0)
-		printf("ERROR: Can't open \"%s\" PCM device. %s\n",
-		       PCM_DEVICE, snd_strerror(pcm));
-	/* Allocate parameters object and fill it with default values*/
-	snd_pcm_hw_params_alloca(&params);
-	snd_pcm_hw_params_any(pcm_handle, params);
+	unsigned int pcm;
 	/* Set parameters */
 	pcm = snd_pcm_hw_params_set_access(pcm_handle, params,
 					   SND_PCM_ACCESS_RW_INTERLEAVED);
@@ -92,10 +80,28 @@ snd_pcm_t * init_pcm(unsigned int samplerate)
 	/* Set sample rate */
 	pcm = snd_pcm_hw_params_set_rate_near(pcm_handle, params,
 					      &samplerate,
-					      &dir);
+					      dir);
 	if (pcm < 0)
 		printf("ERROR: Can't set rate. %s\n", snd_strerror(pcm));
 
+}
+
+snd_pcm_t * init_pcm(unsigned int samplerate)
+{
+	snd_pcm_hw_params_t *params;
+	snd_pcm_t *pcm_handle;
+	int dir;
+	unsigned int tmp,pcm;
+	dir = 0;
+	/* Open the PCM device in playback mode */
+	if ((pcm = snd_pcm_open(&pcm_handle, PCM_DEVICE,
+				SND_PCM_STREAM_PLAYBACK, 0)) < 0)
+		printf("ERROR: Can't open \"%s\" PCM device. %s\n",
+		       PCM_DEVICE, snd_strerror(pcm));
+
+	snd_pcm_hw_params_alloca(&params);
+	snd_pcm_hw_params_any(pcm_handle, params);
+	init_pcm_params(pcm_handle, params, samplerate, &dir);
 	/* Resume information */
 	snd_pcm_hw_params_get_channels(params, &tmp);
 	if (tmp == 1)

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.c
@@ -56,7 +56,8 @@ static SNDFILE *infile = NULL;
 #define alloca(x) __builtin_alloca(x)
 #endif
 
-void init_pcm_params(snd_pcm_t *pcm_handle, snd_pcm_hw_params_t *params, unsigned int samplerate, int *dir)
+void init_pcm_params(snd_pcm_t *pcm_handle, snd_pcm_hw_params_t *params,
+		     unsigned int samplerate, int *dir, int channels)
 {
 	unsigned int pcm;
 	/* Set parameters */
@@ -72,7 +73,7 @@ void init_pcm_params(snd_pcm_t *pcm_handle, snd_pcm_hw_params_t *params, unsigne
 		printf("ERROR: Can't set format. %s\n", snd_strerror(pcm));
 
 	/* Setting channels */
-	pcm = snd_pcm_hw_params_set_channels(pcm_handle, params,1);
+	pcm = snd_pcm_hw_params_set_channels(pcm_handle, params,channels);
 	if (pcm < 0)
 		printf("ERROR: Can't set channels number. %s\n",
 		       snd_strerror(pcm));
@@ -101,7 +102,7 @@ snd_pcm_t * init_pcm(unsigned int samplerate)
 
 	snd_pcm_hw_params_alloca(&params);
 	snd_pcm_hw_params_any(pcm_handle, params);
-	init_pcm_params(pcm_handle, params, samplerate, &dir);
+	init_pcm_params(pcm_handle, params, samplerate, &dir, 1);
 	/* Resume information */
 	snd_pcm_hw_params_get_channels(params, &tmp);
 	if (tmp == 1)

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
@@ -7,6 +7,8 @@
 void cleanup_pcm(snd_pcm_t *pcm_handle);
 unsigned int init_sndfile(char *infilename);
 snd_pcm_t * init_pcm(unsigned int samplerate);
+void init_pcm_params(snd_pcm_t *pcm_handle, snd_pcm_hw_params_t *params,
+		     unsigned int samplerate, int *dir, int channels);
 void play_sndfile(snd_pcm_t *pcm_handle);
 void play_wave(snd_pcm_t *pcm_handle, Wave* wav);
 void sound(snd_pcm_t *pcm_handle, short *buf, int readcount);

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/simpleAlsa.h
@@ -4,7 +4,7 @@
 #ifndef SIMPLE_ALSA_H_
 #define SIMPLE_ALSA_H_
 
-void cleanup_pcm(snd_pcm_t **pcm_handle);
+void cleanup_pcm(snd_pcm_t *pcm_handle);
 unsigned int init_sndfile(char *infilename);
 snd_pcm_t * init_pcm(unsigned int samplerate);
 void play_sndfile(snd_pcm_t *pcm_handle);

--- a/bbb/meta-bbb/recipes-core/trebletrouble/files/src/tone.c
+++ b/bbb/meta-bbb/recipes-core/trebletrouble/files/src/tone.c
@@ -9,7 +9,7 @@
 
 #define FFT_SIZE 15
 
-#define BITS_PER_SAMPLE 32
+#define BITS_PER_SAMPLE 16
 
 /* This macro calculates the maximum value for a N-bit signed integer */
 #define MAX_INT(N) ((1<<(N-1))-1)
@@ -63,7 +63,7 @@ float get_pitch(Wave* wave) {
   waveData = calloc(wave->nSamples, sizeof(float));
 
   for (i = 0; i < wave->nSamples; i++) {
-    waveData[i] = ((float)((int*)wave->data)[i])
+    waveData[i] = ((float)((short*)wave->data)[i])
                   / (MAX_INT(wave->header.bitsPerSample));
   }
 
@@ -73,18 +73,13 @@ float get_pitch(Wave* wave) {
 
   max = 0;
   for (i = 0; i < (SAMPLE_RATE / 2); i++) {
-    /* check if there's any imaginary values */
-    /* waveval = sqrt(imaginary_wave[i] * imaginary_wave[i] + wave[i] * wave[i]); */
     if (waveData[i] > max) {
       max = waveData[i];
-	  /* if (samples[i] > max) { */
-	  /* 	  max = samples[i]; */
       max_index = i;
     }
-    /* } */
   }
   free(waveData);
-  pitch = ((float)max_index) * SAMPLE_RATE / (1 << (FFT_SIZE-1));
+  pitch = ((float)max_index) * SAMPLE_RATE / (1 << FFT_SIZE);
 
   return pitch;
 }
@@ -145,11 +140,10 @@ void waveAddSample(Wave* wave, float sample) {
 	sample32bit = (long long int) (MAX_INT(wave->header.bitsPerSample)*sample);
 	toLittleEndian(4, (void*) &sample32bit);
 	sample_bytes = (char*)&sample32bit;
-	wave->data[ wave->index + 0 ] = sample_bytes[0];
-	wave->data[ wave->index + 1 ] = sample_bytes[1];
-	wave->data[ wave->index + 2 ] = sample_bytes[2];
-	wave->data[ wave->index + 3 ] = sample_bytes[3];
-	wave->index += 4;
+	wave->data[ wave->index ++ ] = sample_bytes[0];
+	wave->data[ wave->index ++ ] = sample_bytes[1];
+	/* wave->data[ wave->index ++ ] = sample_bytes[2]; */
+	/* wave->data[ wave->index ++ ] = sample_bytes[3]; */
 }
 
 void waveDestroy( Wave* wave) {


### PR DESCRIPTION
- Make the code compile again >.<
- Fix a segfault bug.
- 16-bit sampling because reasons.
- Factor out the PCM parameter initialization code for both recording and playback. This way changes to it are made in only one place and parameters are largely the same for both directions.
- Adjust down an octave because FFT does not work like we think it does

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trebletrouble/trebletrouble/92)
<!-- Reviewable:end -->
